### PR TITLE
Try checking image format as a stream

### DIFF
--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -348,6 +348,21 @@ class TestOpen(ImageTestCase):
         self.assertIsInstance(Image.open('tests/images/transparent.png').backend, self.FakeBackend)
         self.assertIsInstance(Image.open('tests/images/flower.jpg').backend, self.AnotherFakeBackend)
 
+    def test_image_detect_stream(self):
+        Image.loaders = {
+            'png': [
+                (0, self.FakeBackend),
+            ],
+            'jpeg': [
+                (100, self.AnotherFakeBackend),
+            ],
+        }
+
+        with open('tests/images/transparent.png', 'rb') as f:
+            self.assertIsInstance(Image.open(f).backend, self.FakeBackend)
+        with open('tests/images/flower.jpg', 'rb') as f:
+            self.assertIsInstance(Image.open(f).backend, self.AnotherFakeBackend)
+
 
 class TestLoaderDefaultConfiguration(ImageTestCase):
     pass

--- a/willow/image.py
+++ b/willow/image.py
@@ -54,6 +54,10 @@ class Image(object):
     def open(cls, f, initial_backend=None):
         image_format = imghdr.what(f)
 
+        if image_format is None:
+            f.seek(0)
+            image_format = imghdr.what(f,h=f.read(f.size))
+
         if not initial_backend:
             # Work out best initial backend based on file format
             initial_backend = cls.find_loader(image_format)

--- a/willow/image.py
+++ b/willow/image.py
@@ -55,9 +55,10 @@ class Image(object):
         image_format = imghdr.what(f)
 
         if image_format is None:
-            # The irst image_format method assumes a string with path to a
+            # The first image_format method assumes a string with path to a
             # file. It would also be reasonable to recieve an io stream, so
-            # we can try getting the image format of that as well.
+            # we can try getting the image format of that as well. 
+            # Unfortunately, imghdr.what can only check one at a time.
             f.seek(0)
             image_format = imghdr.what(f,h=f.read(f.size))
 

--- a/willow/image.py
+++ b/willow/image.py
@@ -55,6 +55,9 @@ class Image(object):
         image_format = imghdr.what(f)
 
         if image_format is None:
+            # The irst image_format method assumes a string with path to a
+            # file. It would also be reasonable to recieve an io stream, so
+            # we can try getting the image format of that as well.
             f.seek(0)
             image_format = imghdr.what(f,h=f.read(f.size))
 


### PR DESCRIPTION
Sometimes, the file that Willow will get is a BytesIO stream rather than a path string. Since `imghdr` can determine the image format from the stream as well, I figure we might as well try it.
