### PR TITLE
Let PIL save the icc profil

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+##########################################################
+####    WhiteSource Integration configuration file    ####
+##########################################################
+
+# Configuration #
+#---------------#
+ws.repo.scan=true
+vulnerable.check.run.conclusion.level=failure

--- a/willow/backends/pillow.py
+++ b/willow/backends/pillow.py
@@ -67,7 +67,7 @@ def save_as_jpeg(backend, f, quality=85):
     if backend.image.mode in ['1', 'P']:
         backend.image = backend.image.convert('RGB')
 
-    backend.image.save(f, 'JPEG', quality=quality)
+    backend.image.save(f, 'JPEG', quality=quality, icc_profile=backend.image.info.get('icc_profile'))
 
 
 @PillowBackend.register_operation('save_as_png')


### PR DESCRIPTION
Some images have icc profiles embed. PIL would just strip them without icc_profile as parameter.
