### PR TITLE
Add rotate operation for Willow - Images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /Willow.egg-info
 /dist
 /venv
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ Operation                           Pillow               Wand                 Op
 ``get_size()``                      ✓                    ✓                    ✓
 ``resize(size)``                    ✓                    ✓
 ``crop(rect)``                      ✓                    ✓
+``rotate(angle)``                   ✓                    ✓
 ``set_background_color_rgb(color)`` ✓                    ✓
 ``auto_orient()``                   ✓                    ✓
 ``save_as_jpeg(file, quality)``     ✓                    ✓

--- a/docs/guide/operations.rst
+++ b/docs/guide/operations.rst
@@ -42,6 +42,21 @@ original image is not modified.
     isinstance(i, Image)
     i.get_size() == (100, 100)
 
+Rotating images
+---------------
+
+To rotate an image, call the :meth:`~Image.rotate` method. This rotates the image clockwise, by a multiple of 90 degrees (i.e 90, 180, 270).
+
+It returns a new :class:`~Image` object containing the rotated image. The
+original image is not modified.
+
+.. code-block:: python
+    # in this case, assume 'i' is a 300x150 pixel image
+    i = i.rotate(90)
+    isinstance(i, Image)
+    i.get_size() == (150, 300)
+
+
 Cropping images
 ---------------
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -38,6 +38,17 @@ class TestPillowOperations(unittest.TestCase):
         with self.assertRaises(UnsupportedRotation) as e:
             rotated_image = self.image.rotate(45)
 
+    def test_rotate_greater_than_360(self):
+        # 450 should end up the same as a 90 rotation
+        rotated_image = self.image.rotate(450)
+        width, height = rotated_image.get_size()
+        self.assertEqual((width, height), (150, 200))
+
+    def test_rotate_multiple_of_360(self):
+        rotated_image = self.image.rotate(720)
+        width, height = rotated_image.get_size()
+        self.assertEqual((width, height), (200, 150))
+
     def test_set_background_color_rgb(self):
         red_background_image = self.image.set_background_color_rgb((255, 0, 0))
         self.assertFalse(red_background_image.has_alpha())

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -5,7 +5,7 @@ import imghdr
 from PIL import Image as PILImage
 
 from willow.image import JPEGImageFile, PNGImageFile, GIFImageFile, WebPImageFile
-from willow.plugins.pillow import _PIL_Image, PillowImage
+from willow.plugins.pillow import _PIL_Image, PillowImage, UnsupportedRotation
 
 
 no_webp_support = not PillowImage.is_format_supported("WEBP")
@@ -28,6 +28,15 @@ class TestPillowOperations(unittest.TestCase):
     def test_crop(self):
         cropped_image = self.image.crop((10, 10, 100, 100))
         self.assertEqual(cropped_image.get_size(), (90, 90))
+
+    def test_rotate(self):
+        rotated_image = self.image.rotate(90)
+        width, height = rotated_image.get_size()
+        self.assertEqual((width, height), (150, 200))
+
+    def test_rotate_without_multiple_of_90(self):
+        with self.assertRaises(UnsupportedRotation) as e:
+            rotated_image = self.image.rotate(45)
 
     def test_set_background_color_rgb(self):
         red_background_image = self.image.set_background_color_rgb((255, 0, 0))

--- a/tests/test_wand.py
+++ b/tests/test_wand.py
@@ -40,6 +40,17 @@ class TestWandOperations(unittest.TestCase):
         with self.assertRaises(UnsupportedRotation) as e:
             rotated_image = self.image.rotate(45)
 
+    def test_rotate_greater_than_360(self):
+        # 450 should end up the same as a 90 rotation
+        rotated_image = self.image.rotate(450)
+        width, height = rotated_image.get_size()
+        self.assertEqual((width, height), (150, 200))
+
+    def test_rotate_multiple_of_360(self):
+        rotated_image = self.image.rotate(720)
+        width, height = rotated_image.get_size()
+        self.assertEqual((width, height), (200, 150))
+
     def test_set_background_color_rgb(self):
         red_background_image = self.image.set_background_color_rgb((255, 0, 0))
         self.assertFalse(red_background_image.has_alpha())

--- a/tests/test_wand.py
+++ b/tests/test_wand.py
@@ -7,7 +7,7 @@ from wand.color import Color
 from PIL import Image as PILImage
 
 from willow.image import JPEGImageFile, PNGImageFile, GIFImageFile, WebPImageFile
-from willow.plugins.wand import _wand_image, WandImage
+from willow.plugins.wand import _wand_image, WandImage, UnsupportedRotation
 
 
 no_webp_support = not WandImage.is_format_supported("WEBP")
@@ -30,6 +30,15 @@ class TestWandOperations(unittest.TestCase):
     def test_crop(self):
         cropped_image = self.image.crop((10, 10, 100, 100))
         self.assertEqual(cropped_image.get_size(), (90, 90))
+
+    def test_rotate(self):
+        rotated_image = self.image.rotate(90)
+        width, height = rotated_image.get_size()
+        self.assertEqual((width, height), (150, 200))
+
+    def test_rotate_without_multiple_of_90(self):
+        with self.assertRaises(UnsupportedRotation) as e:
+            rotated_image = self.image.rotate(45)
 
     def test_set_background_color_rgb(self):
         red_background_image = self.image.set_background_color_rgb((255, 0, 0))

--- a/willow/plugins/pillow.py
+++ b/willow/plugins/pillow.py
@@ -192,6 +192,17 @@ class PillowImage(Image):
 
         return cls(image)
 
+    @Image.operation
+    def rotate(self, angle):
+        image = self.image
+
+        if angle > 360:
+            angle = 360
+        elif angle < -360:
+            angle = -360
+        
+        return PillowImage(self.image.rotate(angle))
+
     @Image.converter_to(RGBImageBuffer)
     def to_buffer_rgb(self):
         image = self.image

--- a/willow/plugins/pillow.py
+++ b/willow/plugins/pillow.py
@@ -75,13 +75,20 @@ class PillowImage(Image):
         ORIENTATION_TO_TRANSPOSE = {
             90: Image.ROTATE_90,
             180: Image.ROTATE_180,
-            270: Image.ROTATE_270
+            270: Image.ROTATE_270,
         }
-        transpose_code = ORIENTATION_TO_TRANSPOSE.get(angle)
+
+        modulo_angle = angle % 360
+
+        # is we're rotating a multiple of 360, it's the same as a no-op
+        if not modulo_angle:
+            return self
+
+        transpose_code = ORIENTATION_TO_TRANSPOSE.get(modulo_angle)
 
         if not transpose_code:
             raise UnsupportedRotation(
-                "Sorry - we only support rotations by 90, 180, or 270 degrees"
+                "Sorry - we only support right angle rotations - i.e. multiples of 90 degrees"
             )
 
         # We call "transpose", as it rotates the image,

--- a/willow/plugins/pillow.py
+++ b/willow/plugins/pillow.py
@@ -13,7 +13,7 @@ from willow.image import (
 )
 
 class UnsupportedRotation(Exception): pass
-    
+
 def _PIL_Image():
     import PIL.Image
     return PIL.Image
@@ -65,7 +65,7 @@ class PillowImage(Image):
         return PillowImage(self.image.crop(rect))
 
     @Image.operation
-    def rotate(self, angle=90):
+    def rotate(self, angle):
         """
         Accept a multiple of 90 to pass to the underlying Pillow function
         to rotate the image.

--- a/willow/plugins/wand.py
+++ b/willow/plugins/wand.py
@@ -159,6 +159,18 @@ class WandImage(Image):
     @Image.operation
     def get_wand_image(self):
         return self.image
+    
+    @Image.operation
+    def rotate(self, angle, background_color = 'rgb(0,255,0)'):
+        new_image = self._clone().image
+        print('here in wand code')
+
+        if angle > 360:
+            angle = 360
+        elif angle < -360:
+            angle = -360
+        
+        return new_image.rotate(angle, _wand_color().Color(background_color))
 
     @classmethod
     @Image.converter_from(JPEGImageFile, cost=150)

--- a/willow/plugins/wand.py
+++ b/willow/plugins/wand.py
@@ -14,6 +14,7 @@ from willow.image import (
     WebPImageFile,
 )
 
+class UnsupportedRotation(Exception): pass
 
 def _wand_image():
     import wand.image
@@ -76,6 +77,19 @@ class WandImage(Image):
         clone = self._clone()
         clone.image.crop(left=rect[0], top=rect[1], right=rect[2], bottom=rect[3])
         return clone
+
+    @Image.operation
+    def rotate(self, angle=90):
+        not_a_multiple_of_90 = angle % 90
+
+        if not_a_multiple_of_90:
+            raise UnsupportedRotation(
+                "Sorry - we only support rotations by 90, 180, or 270 degrees"
+            )
+
+        clone = self.image.clone()
+        clone.rotate(angle)
+        return WandImage(clone)
 
     @Image.operation
     def set_background_color_rgb(self, color):
@@ -159,18 +173,6 @@ class WandImage(Image):
     @Image.operation
     def get_wand_image(self):
         return self.image
-    
-    @Image.operation
-    def rotate(self, angle, background_color = 'rgb(0,255,0)'):
-        new_image = self._clone().image
-        print('here in wand code')
-
-        if angle > 360:
-            angle = 360
-        elif angle < -360:
-            angle = -360
-        
-        return new_image.rotate(angle, _wand_color().Color(background_color))
 
     @classmethod
     @Image.converter_from(JPEGImageFile, cost=150)

--- a/willow/plugins/wand.py
+++ b/willow/plugins/wand.py
@@ -79,7 +79,7 @@ class WandImage(Image):
         return clone
 
     @Image.operation
-    def rotate(self, angle=90):
+    def rotate(self, angle):
         not_a_multiple_of_90 = angle % 90
 
         if not_a_multiple_of_90:

--- a/willow/plugins/wand.py
+++ b/willow/plugins/wand.py
@@ -84,7 +84,7 @@ class WandImage(Image):
 
         if not_a_multiple_of_90:
             raise UnsupportedRotation(
-                "Sorry - we only support rotations by 90, 180, or 270 degrees"
+                "Sorry - we only support right angle rotations - i.e. multiples of 90 degrees"
             )
 
         clone = self.image.clone()


### PR DESCRIPTION
Hi there,

I'm opening a PR here, partly to start some work being able to work on issue #2901 on the main wagtail repo.

#https://github.com/wagtail/wagtail/issues/2901

As I understand it at the mo, I'd need to implement rotate()  transformations along the lines of:

```python
@Image.operation
    def rotate(self, size):
        image = self.image
        return PillowImage(image.rotate(90, expand=True))
```

…for Pillow, and Wand, before I can call these higher up the stack from within Wagtail, in the image editing view, 

Would you let me know if this is the case? If so, I'll implement the other rotate method, and start on making the necessary changes for a PR on Wagtail too.