### PR TITLE
Altered `detect_features` in opencv to return a list 

### DIFF
--- a/tests/test_opencv.py
+++ b/tests/test_opencv.py
@@ -32,11 +32,13 @@ class TestOpenCVOperations(unittest.TestCase):
     def test_detect_features(self):
         features = self.image.detect_features()
 
+        self.assertIsInstance(features, list)
         # There are 20 features in the image
         self.assertEqual(len(features), 20)
 
     def test_detect_faces(self):
         faces = self.image.detect_faces()
 
+        self.assertIsInstance(faces, list)
         # There are two faces in the image
         self.assertEqual(len(faces), 2)

--- a/willow/plugins/opencv.py
+++ b/willow/plugins/opencv.py
@@ -76,7 +76,10 @@ class OpenCVGrayscaleImage(BaseOpenCVImage):
         """
         cv2 = _cv2()
         points = cv2.goodFeaturesToTrack(self.image, 20, 0.04, 1.0)
-        return points.tolist()
+        if points is None:
+            return []
+        else:
+            return points.tolist()
 
     @Image.operation
     def detect_faces(self, cascade_filename='haarcascade_frontalface_alt2.xml'):

--- a/willow/plugins/opencv.py
+++ b/willow/plugins/opencv.py
@@ -76,7 +76,7 @@ class OpenCVGrayscaleImage(BaseOpenCVImage):
         """
         cv2 = _cv2()
         points = cv2.goodFeaturesToTrack(self.image, 20, 0.04, 1.0)
-        return points
+        return points.tolist()
 
     @Image.operation
     def detect_faces(self, cascade_filename='haarcascade_frontalface_alt2.xml'):


### PR DESCRIPTION
When using OpenCV 3, it was returning a numpy array. The numpy array caused incompatibilities when used with Wagtail (running 1.10.1).

When wagtail images attempts to get the focal points it throws `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()` on `if features:`.

Having the `detect_features` return a list will keep the interface consistent since `detect_faces` also returns a list.

## wagtail.wagtailimages.models.AbstractImage:
```py
    def get_suggested_focal_point(self):
        with self.get_willow_image() as willow:
            faces = willow.detect_faces()

            if faces:
                # Create a bounding box around all faces
                left = min(face[0] for face in faces)
                top = min(face[1] for face in faces)
                right = max(face[2] for face in faces)
                bottom = max(face[3] for face in faces)
                focal_point = Rect(left, top, right, bottom)
            else:
                features = willow.detect_features()
                if features:  # <-- Throws ValueError
                    # Create a bounding box around all features
                    left = min(feature[0] for feature in features)
                    top = min(feature[1] for feature in features)
                    right = max(feature[0] for feature in features)
                    bottom = max(feature[1] for feature in features)
                    focal_point = Rect(left, top, right, bottom)
                else:
                    return None
```