### PR TITLE
Reshaping Feature Array

### DIFF
--- a/tests/test_opencv.py
+++ b/tests/test_opencv.py
@@ -32,11 +32,13 @@ class TestOpenCVOperations(unittest.TestCase):
     def test_detect_features(self):
         features = self.image.detect_features()
 
+        self.assertIsInstance(features, list)
         # There are 20 features in the image
         self.assertEqual(len(features), 20)
 
     def test_detect_faces(self):
         faces = self.image.detect_faces()
 
+        self.assertIsInstance(faces, list)
         # There are two faces in the image
         self.assertEqual(len(faces), 2)

--- a/tests/test_opencv.py
+++ b/tests/test_opencv.py
@@ -16,6 +16,13 @@ class TestOpenCVOperations(unittest.TestCase):
             colour_image = OpenCVColorImage.from_buffer_rgb(buffer_rgb)
             self.image = OpenCVGrayscaleImage.from_color(colour_image)
 
+        self.expected_features = [
+            [41.0, 206.0], [16.0, 201.0], [243.0, 208.0], [79.0, 130.0], [120.0, 24.0], [43.0, 119.0], [40.0, 165.0],
+            [37.0, 14.0], [250.0, 59.0], [98.0, 6.0], [78.0, 61.0], [201.0, 93.0], [8.0, 114.0], [189.0, 142.0],
+            [292.0, 188.0], [201.0, 199.0], [7.0, 154.0], [198.0, 247.0], [235.0, 55.0], [22.0, 36.0]
+        ]
+        self.expected_faces = [(272, 89, 364, 181), (91, 165, 187, 261)]
+
     def test_get_size(self):
         width, height = self.image.get_size()
         self.assertEqual(width, 600)
@@ -33,6 +40,7 @@ class TestOpenCVOperations(unittest.TestCase):
         features = self.image.detect_features()
 
         self.assertIsInstance(features, list)
+        self.assertEqual(features, self.expected_features)
         # There are 20 features in the image
         self.assertEqual(len(features), 20)
 
@@ -40,5 +48,6 @@ class TestOpenCVOperations(unittest.TestCase):
         faces = self.image.detect_faces()
 
         self.assertIsInstance(faces, list)
+        self.assertEqual(faces, self.expected_faces)
         # There are two faces in the image
         self.assertEqual(len(faces), 2)

--- a/willow/plugins/opencv.py
+++ b/willow/plugins/opencv.py
@@ -76,7 +76,10 @@ class OpenCVGrayscaleImage(BaseOpenCVImage):
         """
         cv2 = _cv2()
         points = cv2.goodFeaturesToTrack(self.image, 20, 0.04, 1.0)
-        return points.tolist()
+        if points is None:
+            return []
+        else:
+            return points.tolist()
 
     @Image.operation
     def detect_faces(self, cascade_filename='haarcascade_frontalface_alt2.xml'):

--- a/willow/plugins/opencv.py
+++ b/willow/plugins/opencv.py
@@ -74,11 +74,13 @@ class OpenCVGrayscaleImage(BaseOpenCVImage):
         """
         Find interesting features of an image suitable for cropping to.
         """
+        numpy = _numpy()
         cv2 = _cv2()
         points = cv2.goodFeaturesToTrack(self.image, 20, 0.04, 1.0)
         if points is None:
             return []
         else:
+            points = numpy.reshape(points, (-1, 2))  # Numpy returns it with an extra third dimension
             return points.tolist()
 
     @Image.operation

--- a/willow/plugins/opencv.py
+++ b/willow/plugins/opencv.py
@@ -76,7 +76,7 @@ class OpenCVGrayscaleImage(BaseOpenCVImage):
         """
         cv2 = _cv2()
         points = cv2.goodFeaturesToTrack(self.image, 20, 0.04, 1.0)
-        return points
+        return points.tolist()
 
     @Image.operation
     def detect_faces(self, cascade_filename='haarcascade_frontalface_alt2.xml'):


### PR DESCRIPTION
From OpenCV 1 to OpenCV 2/3 there is an additional array wrapping each of the feature points. So in OpenCV 1 two feature points of [20, 40] and [30,50] would have been returned as 
```py
[
     [20,40], 
     [30, 50]
]
``` 

With the switch to numpy they were being returned as 
```py
[
     [
         [20,40]
     ], 
     [
         [30, 50]
     ]
]
``` 

Added tests to verify the values of the features/facial points to catch this in the future.