### PR TITLE
Implement set_background_color_rgb operation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ Operation                           Pillow               Wand                 Op
 ``get_size()``                      ✓                    ✓                    ✓
 ``resize(size)``                    ✓                    ✓
 ``crop(rect)``                      ✓                    ✓
+``set_background_color_rgb(color)`` ✓                    ✓
 ``auto_orient()``                   ✓                    ✓
 ``save_as_jpeg(file, quality)``     ✓                    ✓
 ``save_as_png(file)``               ✓                    ✓

--- a/docs/guide/operations.rst
+++ b/docs/guide/operations.rst
@@ -70,12 +70,14 @@ background colour using the :meth:`~Image.set_background_color_rgb` method.
 It takes the background color as a three element tuple of integers between
 0 - 255 (representing the red, green and blue channels respectively).
 
+It returns a new :class:`~Image` object containing the background color and
+the alpha channel removed. The original image is not modified.
+
 .. code-block:: python
 
     # Sets background color to white
     i = i.set_background_color_rgb((255, 255, 255))
 
-    # This operation will remove the alpha channel from the image
     isinstance(i, Image)
     i.has_alpha() == False
 

--- a/docs/guide/operations.rst
+++ b/docs/guide/operations.rst
@@ -61,6 +61,24 @@ original image is not modified.
     isinstance(i, Image)
     i.get_size() == (200, 200)
 
+Setting a background colour
+---------------------------
+
+If the image has transparency, you can replace the transparency with a solid
+background colour using the :meth:`~Image.set_background_color_rgb` method.
+
+It takes the background color as a three element tuple of integers between
+0 - 255 (representing the red, green and blue channels respectively).
+
+.. code-block:: python
+
+    # Sets background color to white
+    i = i.set_background_color_rgb((255, 255, 255))
+
+    # This operation will remove the alpha channel from the image
+    isinstance(i, Image)
+    i.has_alpha() == False
+
 Detecting features
 ------------------
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -139,6 +139,25 @@ Here's a full list of operations provided by Willow out of the box:
         # Cut out a square from the middle of the image
         cropped_image = source_image.resize((100, 100, 200, 200))
 
+.. method:: set_background_color_rgb(color)
+
+    (Pillow/Wand only)
+
+    If the image has an alpha channel, this will add a background colour using
+    the alpha channel as a mask. The alpha channel will be removed from the
+    resulting image.
+
+    The background colour must be specified as a tuple of three integers with
+    values between 0 - 255.
+
+    This operation will convert the image to RGB format, but will not do
+    anything if there is not an alpha channel.
+
+    .. code-block:: python
+
+        # Set the background colour of the image to white
+        image = source_image.set_background_color_rgb((255, 255, 255))
+
 .. method:: auto_orient()
 
     (Pillow/Wand only)
@@ -191,6 +210,11 @@ Here's a full list of operations provided by Willow out of the box:
     (Pillow/Wand only)
 
     Saves the image to the specified file-like object in JPEG format.
+
+    Note: If the image has an alpha channel, this operation may raise an
+    exception or save a broken image (depending on the backend being used).
+    To resolve this, use the :meth:`~Image.set_background_color_rgb` method to
+    replace the alpha channel with a solid background color before saving as JPEG.
 
     Returns a ``JPEGImageFile`` wrapping the file.
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -26,6 +26,11 @@ class TestPillowOperations(unittest.TestCase):
         cropped_image = self.image.crop((10, 10, 100, 100))
         self.assertEqual(cropped_image.get_size(), (90, 90))
 
+    def test_set_background_color_rgb(self):
+        red_background_image = self.image.set_background_color_rgb((255, 0, 0))
+        self.assertFalse(red_background_image.has_alpha())
+        self.assertEqual(red_background_image.image.getpixel((10, 10)), (255, 0, 0))
+
     def test_save_as_jpeg(self):
         output = io.BytesIO()
         return_value = self.image.save_as_jpeg(output)

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -31,6 +31,12 @@ class TestPillowOperations(unittest.TestCase):
         self.assertFalse(red_background_image.has_alpha())
         self.assertEqual(red_background_image.image.getpixel((10, 10)), (255, 0, 0))
 
+    def test_set_background_color_rgb_color_argument_check(self):
+        with self.assertRaises(TypeError) as e:
+            self.image.set_background_color_rgb('rgb(255, 0, 0)')
+
+        self.assertEqual(str(e.exception), "the 'color' argument must be a 3-element tuple or list")
+
     def test_save_as_jpeg(self):
         # Remove alpha channel from image
         image = self.image.set_background_color_rgb((255, 255, 255))

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -32,8 +32,11 @@ class TestPillowOperations(unittest.TestCase):
         self.assertEqual(red_background_image.image.getpixel((10, 10)), (255, 0, 0))
 
     def test_save_as_jpeg(self):
+        # Remove alpha channel from image
+        image = self.image.set_background_color_rgb((255, 255, 255))
+
         output = io.BytesIO()
-        return_value = self.image.save_as_jpeg(output)
+        return_value = image.save_as_jpeg(output)
         output.seek(0)
 
         self.assertEqual(imghdr.what(output), 'jpeg')
@@ -41,14 +44,20 @@ class TestPillowOperations(unittest.TestCase):
         self.assertEqual(return_value.f, output)
 
     def test_save_as_jpeg_optimised(self):
-        unoptimised = self.image.save_as_jpeg(io.BytesIO())
-        optimised = self.image.save_as_jpeg(io.BytesIO(), optimize=True)
+        # Remove alpha channel from image
+        image = self.image.set_background_color_rgb((255, 255, 255))
+
+        unoptimised = image.save_as_jpeg(io.BytesIO())
+        optimised = image.save_as_jpeg(io.BytesIO(), optimize=True)
 
         # Optimised image must be smaller than unoptimised image
         self.assertTrue(optimised.f.tell() < unoptimised.f.tell())
 
     def test_save_as_jpeg_progressive(self):
-        image = self.image.save_as_jpeg(io.BytesIO(), progressive=True)
+        # Remove alpha channel from image
+        image = self.image.set_background_color_rgb((255, 255, 255))
+
+        image = image.save_as_jpeg(io.BytesIO(), progressive=True)
 
         self.assertTrue(PILImage.open(image.f).info['progressive'])
 

--- a/tests/test_wand.py
+++ b/tests/test_wand.py
@@ -28,6 +28,14 @@ class TestWandOperations(unittest.TestCase):
         cropped_image = self.image.crop((10, 10, 100, 100))
         self.assertEqual(cropped_image.get_size(), (90, 90))
 
+    def test_set_background_color_rgb(self):
+        red_background_image = self.image.set_background_color_rgb((255, 0, 0))
+        self.assertFalse(red_background_image.has_alpha())
+        colour = red_background_image.image[10][10]
+        self.assertEqual(colour.red, 1.0)
+        self.assertEqual(colour.green, 0.0)
+        self.assertEqual(colour.blue, 0.0)
+
     def test_save_as_jpeg(self):
         output = io.BytesIO()
         return_value = self.image.save_as_jpeg(output)

--- a/tests/test_wand.py
+++ b/tests/test_wand.py
@@ -36,6 +36,12 @@ class TestWandOperations(unittest.TestCase):
         self.assertEqual(colour.green, 0.0)
         self.assertEqual(colour.blue, 0.0)
 
+    def test_set_background_color_rgb_color_argument_check(self):
+        with self.assertRaises(TypeError) as e:
+            self.image.set_background_color_rgb('rgb(255, 0, 0)')
+
+        self.assertEqual(str(e.exception), "the 'color' argument must be a 3-element tuple or list")
+
     def test_save_as_jpeg(self):
         # Remove alpha channel from image
         image = self.image.set_background_color_rgb((255, 255, 255))

--- a/tests/test_wand.py
+++ b/tests/test_wand.py
@@ -37,8 +37,11 @@ class TestWandOperations(unittest.TestCase):
         self.assertEqual(colour.blue, 0.0)
 
     def test_save_as_jpeg(self):
+        # Remove alpha channel from image
+        image = self.image.set_background_color_rgb((255, 255, 255))
+
         output = io.BytesIO()
-        return_value = self.image.save_as_jpeg(output)
+        return_value = image.save_as_jpeg(output)
         output.seek(0)
 
         self.assertEqual(imghdr.what(output), 'jpeg')
@@ -47,14 +50,20 @@ class TestWandOperations(unittest.TestCase):
 
     @unittest.expectedFailure
     def test_save_as_jpeg_optimised(self):
-        unoptimised = self.image.save_as_jpeg(io.BytesIO())
-        optimised = self.image.save_as_jpeg(io.BytesIO(), optimize=True)
+        # Remove alpha channel from image
+        image = self.image.set_background_color_rgb((255, 255, 255))
+
+        unoptimised = image.save_as_jpeg(io.BytesIO())
+        optimised = image.save_as_jpeg(io.BytesIO(), optimize=True)
 
         # Optimised image must be smaller than unoptimised image
         self.assertTrue(optimised.f.tell() < unoptimised.f.tell())
 
     def test_save_as_jpeg_progressive(self):
-        image = self.image.save_as_jpeg(io.BytesIO(), progressive=True)
+        # Remove alpha channel from image
+        image = self.image.set_background_color_rgb((255, 255, 255))
+
+        image = image.save_as_jpeg(io.BytesIO(), progressive=True)
 
         self.assertTrue(PILImage.open(image.f).info['progressive'])
 

--- a/willow/plugins/pillow.py
+++ b/willow/plugins/pillow.py
@@ -63,6 +63,10 @@ class PillowImage(Image):
             # Don't change image that doesn't have an alpha channel
             return self
 
+        # Check type of color
+        if not isinstance(color, (tuple, list)) or not len(color) == 3:
+            raise TypeError("the 'color' argument must be a 3-element tuple or list")
+
         # Convert non-RGB colour formats to RGB
         # As we only allow the background color to be passed in as RGB, we
         # convert the format of the original image to match.

--- a/willow/plugins/pillow.py
+++ b/willow/plugins/pillow.py
@@ -58,6 +58,24 @@ class PillowImage(Image):
         return PillowImage(self.image.crop(rect))
 
     @Image.operation
+    def set_background_color_rgb(self, color):
+        if not self.has_alpha():
+            # Don't change image that doesn't have an alpha channel
+            return self
+
+        # Convert non-RGB colour formats to RGB
+        # As we only allow the background color to be passed in as RGB, we
+        # convert the format of the original image to match.
+        image = self.image.convert('RGBA')
+
+        # Generate a new image with background colour and draw existing image on top of it
+        # The new image must temporarily be RGBA in order for alpha_composite to work
+        new_image = _PIL_Image().new('RGBA', self.image.size, (color[0], color[1], color[2], 255))
+        new_image.alpha_composite(image)
+
+        return PillowImage(new_image.convert('RGB'))
+
+    @Image.operation
     def save_as_jpeg(self, f, quality=85, optimize=False, progressive=False):
         if self.image.mode in ['1', 'P']:
             image = self.image.convert('RGB')

--- a/willow/plugins/pillow.py
+++ b/willow/plugins/pillow.py
@@ -71,7 +71,13 @@ class PillowImage(Image):
         # Generate a new image with background colour and draw existing image on top of it
         # The new image must temporarily be RGBA in order for alpha_composite to work
         new_image = _PIL_Image().new('RGBA', self.image.size, (color[0], color[1], color[2], 255))
-        new_image.alpha_composite(image)
+
+        if hasattr(new_image, 'alpha_composite'):
+            new_image.alpha_composite(image)
+        else:
+            # Pillow < 4.2.0 fallback
+            # This method may be slower as the operation generates a new image
+            new_image = _PIL_Image().alpha_composite(new_image, image)
 
         return PillowImage(new_image.convert('RGB'))
 

--- a/willow/plugins/wand.py
+++ b/willow/plugins/wand.py
@@ -19,6 +19,11 @@ def _wand_image():
     return wand.image
 
 
+def _wand_color():
+    import wand.color
+    return wand.color
+
+
 def _wand_api():
     import wand.api
     return wand.api
@@ -31,6 +36,7 @@ class WandImage(Image):
     @classmethod
     def check(cls):
         _wand_image()
+        _wand_color()
         _wand_api()
 
     def _clone(self):
@@ -58,6 +64,23 @@ class WandImage(Image):
     def crop(self, rect):
         clone = self._clone()
         clone.image.crop(left=rect[0], top=rect[1], right=rect[2], bottom=rect[3])
+        return clone
+
+    @Image.operation
+    def set_background_color_rgb(self, color):
+        if not self.has_alpha():
+            # Don't change image that doesn't have an alpha channel
+            return self
+
+        clone = self._clone()
+
+        # Wand will perform the compositing at the point of setting alpha_channel to 'remove'
+        clone.image.background_color = _wand_color().Color('rgb({}, {}, {})'.format(*color))
+        clone.image.alpha_channel = 'remove'
+
+        # Set alpha_channel to False manually as Wand doesn't do it
+        clone.image.alpha_channel = False
+
         return clone
 
     @Image.operation

--- a/willow/plugins/wand.py
+++ b/willow/plugins/wand.py
@@ -72,6 +72,10 @@ class WandImage(Image):
             # Don't change image that doesn't have an alpha channel
             return self
 
+        # Check type of color
+        if not isinstance(color, (tuple, list)) or not len(color) == 3:
+            raise TypeError("the 'color' argument must be a 3-element tuple or list")
+
         clone = self._clone()
 
         # Wand will perform the compositing at the point of setting alpha_channel to 'remove'


### PR DESCRIPTION
Ref: #60

This allows the user to replace the alpha channel of an image with a solid colour allowing an images with transparency to be saved JPEG without crashing (Pillow) or screwing up the image (Wand).