### PR TITLE
fix save_as_jpeg failing on rgba images

### DIFF
--- a/willow/plugins/pillow.py
+++ b/willow/plugins/pillow.py
@@ -87,7 +87,7 @@ class PillowImage(Image):
 
     @Image.operation
     def save_as_jpeg(self, f, quality=85, optimize=False, progressive=False):
-        if self.image.mode in ['1', 'P']:
+        if self.image.mode in ['1', 'P', 'RGBA']:
             image = self.image.convert('RGB')
         else:
             image = self.image


### PR DESCRIPTION
as it states here https://github.com/python-pillow/Pillow/issues/2609 we now need to explicitly convert rgba to rgb before converting to jpg