### PR TITLE
Add travis jobs for ppc64le. Install libmagickwand-dev for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+arch:
+    - amd64
+    - ppc64le
 
 # Test matrix
 python:
@@ -12,7 +15,18 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
+    - python: 3.7
+      dist: xenial
+      arch: ppc64le
+      sudo: true
 
+before_install:
+  - >
+    if [[ "$TRAVIS_CPU_ARCH" == ppc64le ]]; then
+      sudo apt-get update;
+      sudo apt-get -y install libmagickwand-dev;
+    fi 
+    
 # Package installation
 install:
   - pip install Pillow Wand


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.