### PR TITLE
Gracefully handle out-of-bounds crops

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -140,12 +140,18 @@ Here's a full list of operations provided by Willow out of the box:
     (Pillow/Wand only)
 
     Cuts out the specified region of the image. The region must be a sequence of
-    four integers (top, left, right, bottom):
+    four integers (left, top, right, bottom):
 
     .. code-block:: python
 
         # Cut out a square from the middle of the image
         cropped_image = source_image.resize((100, 100, 200, 200))
+
+    If the crop rectangle overlaps the image boundaries, it will be reduced to fit within those
+    boundaries, resulting in an output image smaller than specified. If the crop rectangle is
+    entirely outside the image, or the coordinates are out of range in any other way (such as
+    a left coordinate greater than the right coordinate), this throws a
+    :class:`willow.image.BadImageOperationError` (a subclass of :class:`ValueError`).
 
 .. method:: set_background_color_rgb(color)
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -4,7 +4,9 @@ import imghdr
 
 from PIL import Image as PILImage
 
-from willow.image import JPEGImageFile, PNGImageFile, GIFImageFile, WebPImageFile
+from willow.image import (
+    JPEGImageFile, PNGImageFile, GIFImageFile, WebPImageFile, BadImageOperationError
+)
 from willow.plugins.pillow import _PIL_Image, PillowImage, UnsupportedRotation
 
 
@@ -32,6 +34,52 @@ class TestPillowOperations(unittest.TestCase):
     def test_crop(self):
         cropped_image = self.image.crop((10, 10, 100, 100))
         self.assertEqual(cropped_image.get_size(), (90, 90))
+
+    def test_crop_out_of_bounds(self):
+        # crop rectangle should be clamped to the image boundaries
+        bottom_right_cropped_image = self.image.crop((150, 100, 250, 200))
+        self.assertEqual(bottom_right_cropped_image.get_size(), (50, 50))
+
+        top_left_cropped_image = self.image.crop((-50, -50, 50, 50))
+        self.assertEqual(top_left_cropped_image.get_size(), (50, 50))
+
+        # fail if the crop rectangle is entirely to the left of the image
+        with self.assertRaises(BadImageOperationError):
+            self.image.crop((-100, 50, -50, 100))
+        # right edge of crop rectangle is exclusive, so 0 is also invalid
+        with self.assertRaises(BadImageOperationError):
+            self.image.crop((-50, 50, 0, 100))
+
+        # fail if the crop rectangle is entirely above the image
+        with self.assertRaises(BadImageOperationError):
+            self.image.crop((50, -100, 100, -50))
+        # bottom edge of crop rectangle is exclusive, so 0 is also invalid
+        with self.assertRaises(BadImageOperationError):
+            self.image.crop((50, -50, 100, 0))
+
+        # fail if the crop rectangle is entirely to the right of the image
+        with self.assertRaises(BadImageOperationError):
+            self.image.crop((250, 50, 300, 100))
+        with self.assertRaises(BadImageOperationError):
+            self.image.crop((200, 50, 250, 100))
+
+        # fail if the crop rectangle is entirely below the image
+        with self.assertRaises(BadImageOperationError):
+            self.image.crop((50, 200, 100, 250))
+        with self.assertRaises(BadImageOperationError):
+            self.image.crop((50, 150, 100, 200))
+
+        # fail if left edge >= right edge
+        with self.assertRaises(BadImageOperationError):
+            self.image.crop((125, 25, 25, 125))
+        with self.assertRaises(BadImageOperationError):
+            self.image.crop((100, 25, 100, 125))
+
+        # fail if bottom edge >= top edge
+        with self.assertRaises(BadImageOperationError):
+            self.image.crop((25, 125, 125, 25))
+        with self.assertRaises(BadImageOperationError):
+            self.image.crop((25, 100, 125, 100))
 
     def test_rotate(self):
         rotated_image = self.image.rotate(90)

--- a/willow/image.py
+++ b/willow/image.py
@@ -19,6 +19,14 @@ class UnrecognisedImageFormatError(IOError):
     pass
 
 
+class BadImageOperationError(ValueError):
+    """
+    Raised when the arguments to an image operation are invalid,
+    e.g. a crop where the left coordinate is greater than the right coordinate
+    """
+    pass
+
+
 class Image(object):
     @classmethod
     def check(cls):

--- a/willow/plugins/wand.py
+++ b/willow/plugins/wand.py
@@ -14,6 +14,7 @@ from willow.image import (
     RGBAImageBuffer,
     TIFFImageFile,
     WebPImageFile,
+    BadImageOperationError,
 )
 
 
@@ -83,8 +84,24 @@ class WandImage(Image):
 
     @Image.operation
     def crop(self, rect):
+        left, top, right, bottom = rect
+        width, height = self.image.size
+        if (
+            left >= right or left >= width
+            or right <= 0
+            or top >= bottom or top >= height
+            or bottom <= 0
+        ):
+            raise BadImageOperationError("Invalid crop dimensions: %r" % (rect,))
+
         clone = self._clone()
-        clone.image.crop(left=rect[0], top=rect[1], right=rect[2], bottom=rect[3])
+        clone.image.crop(
+            # clamp to image boundaries
+            left=max(0, left),
+            top=max(0, top),
+            right=min(right, width),
+            bottom=min(bottom, height)
+        )
         return clone
 
     @Image.operation


### PR DESCRIPTION
When passed a crop rectangle that extends outside an image's boundaries, Pillow gracefully returns an image of the requested size (padding with background / transparent pixels as required), but Wand throws a value error. If the calling app is sloppy about dimensions (as is apparently the case in https://github.com/wagtail/wagtail/issues/7766), this will result in errors that only surface when Wand is in use (i.e. for animated gifs).

This PR gives the two backends a consistent "middle ground" behaviour that hopefully makes intuitive sense: the crop rectangle is clamped to the image boundary so that if it overlaps, the final image is smaller than requested. Totally out of bounds or nonsensical parameters (e.g. left > right) will raise a BadImageOperationError.

Fixes https://github.com/wagtail/wagtail/issues/7766, although we'll also want to fix the rounding error that leads to the out-of-bounds condition in the first place.