### PR TITLE
replace deprecated imghdr with filetype

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -10,7 +10,7 @@ The ``Image`` class
 .. classmethod:: open(file)
 
     Opens the provided image file detects the format from the image header using
-    Python's :mod:`imghdr` module.
+    Python's :mod:`filetype` module.
 
     Returns a subclass of :class:`ImageFile`
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,9 @@ setup(
         'Programming Language :: Python :: 3.7',
     ],
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
-    install_requires=[],
+    install_requires=[
+        "filetype>=1.0.10",
+    ],
     extras_require={"testing": [
         "Pillow>=6.0.0,<10.0.0",
         "Wand>=0.6,<1.0",

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,6 +1,7 @@
 import io
 import unittest
 import mock
+import filetype
 
 from willow.image import (
     Image, JPEGImageFile, PNGImageFile, GIFImageFile, UnrecognisedImageFormatError,
@@ -16,8 +17,6 @@ class TestOpenImage(unittest.TestCase):
     these tests do not require valid images.
     """
     def test_opens_jpeg(self):
-        import imghdr
-
         f = io.BytesIO()
         f.write(b'\xff\xd8\xff\xe0\x00\x10JFIF\x00')
         f.seek(0)
@@ -28,8 +27,6 @@ class TestOpenImage(unittest.TestCase):
         self.assertEqual(image.original_format, 'jpeg')
 
     def test_opens_png(self):
-        import imghdr
-
         f = io.BytesIO()
         f.write(b'\x89PNG\x0d\x0a\x1a\x0a')
         f.seek(0)
@@ -40,8 +37,6 @@ class TestOpenImage(unittest.TestCase):
         self.assertEqual(image.original_format, 'png')
 
     def test_opens_gif(self):
-        import imghdr
-
         f = io.BytesIO()
         f.write(b'GIF89a')
         f.seek(0)
@@ -52,8 +47,6 @@ class TestOpenImage(unittest.TestCase):
         self.assertEqual(image.original_format, 'gif')
 
     def test_raises_error_on_invalid_header(self):
-        import imghdr
-
         f = io.BytesIO()
         f.write(b'Not an image')
         f.seek(0)
@@ -111,23 +104,19 @@ class TestSaveImage(unittest.TestCase):
 
 class TestImghdrJPEGPatch(unittest.TestCase):
     def test_detects_photoshop3_jpeg(self):
-        import imghdr
-
         f = io.BytesIO()
         f.write(b'\xff\xd8\xff\xed\x00,Photoshop 3.0\x00')
         f.seek(0)
 
-        image_format = imghdr.what(f)
+        image_format = filetype.guess_extension(f)
 
-        self.assertEqual(image_format, 'jpeg')
+        self.assertEqual(image_format, 'jpg')
 
     def test_junk(self):
-        import imghdr
-
         f = io.BytesIO()
         f.write(b'Not an image')
         f.seek(0)
 
-        image_format = imghdr.what(f)
+        image_format = filetype.guess_extension(f)
 
         self.assertIsNone(image_format)

--- a/tests/test_opencv.py
+++ b/tests/test_opencv.py
@@ -1,6 +1,5 @@
 import unittest
 import io
-import imghdr
 from numpy.testing import assert_allclose
 
 from willow.image import JPEGImageFile

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -1,6 +1,6 @@
 import unittest
 import io
-import imghdr
+import filetype
 
 from PIL import Image as PILImage
 
@@ -120,7 +120,7 @@ class TestPillowOperations(unittest.TestCase):
         return_value = image.save_as_jpeg(output)
         output.seek(0)
 
-        self.assertEqual(imghdr.what(output), 'jpeg')
+        self.assertEqual(filetype.guess_extension(output), 'jpg')
         self.assertIsInstance(return_value, JPEGImageFile)
         self.assertEqual(return_value.f, output)
 
@@ -147,7 +147,7 @@ class TestPillowOperations(unittest.TestCase):
         return_value = self.image.save_as_png(output)
         output.seek(0)
 
-        self.assertEqual(imghdr.what(output), 'png')
+        self.assertEqual(filetype.guess_extension(output), 'png')
         self.assertIsInstance(return_value, PNGImageFile)
         self.assertEqual(return_value.f, output)
 
@@ -163,7 +163,7 @@ class TestPillowOperations(unittest.TestCase):
         return_value = self.image.save_as_gif(output)
         output.seek(0)
 
-        self.assertEqual(imghdr.what(output), 'gif')
+        self.assertEqual(filetype.guess_extension(output), 'gif')
         self.assertIsInstance(return_value, GIFImageFile)
         self.assertEqual(return_value.f, output)
 
@@ -257,7 +257,7 @@ class TestPillowOperations(unittest.TestCase):
         return_value = self.image.save_as_webp(output)
         output.seek(0)
 
-        self.assertEqual(imghdr.what(output), 'webp')
+        self.assertEqual(filetype.guess_extension(output), 'webp')
         self.assertIsInstance(return_value, WebPImageFile)
         self.assertEqual(return_value.f, output)
 

--- a/tests/test_wand.py
+++ b/tests/test_wand.py
@@ -1,6 +1,6 @@
 import unittest
 import io
-import imghdr
+import filetype
 
 from wand.color import Color
 
@@ -125,7 +125,7 @@ class TestWandOperations(unittest.TestCase):
         return_value = image.save_as_jpeg(output)
         output.seek(0)
 
-        self.assertEqual(imghdr.what(output), 'jpeg')
+        self.assertEqual(filetype.guess_extension(output), 'jpg')
         self.assertIsInstance(return_value, JPEGImageFile)
         self.assertEqual(return_value.f, output)
 
@@ -153,7 +153,7 @@ class TestWandOperations(unittest.TestCase):
         return_value = self.image.save_as_png(output)
         output.seek(0)
 
-        self.assertEqual(imghdr.what(output), 'png')
+        self.assertEqual(filetype.guess_extension(output), 'png')
         self.assertIsInstance(return_value, PNGImageFile)
         self.assertEqual(return_value.f, output)
 
@@ -170,7 +170,7 @@ class TestWandOperations(unittest.TestCase):
         return_value = self.image.save_as_gif(output)
         output.seek(0)
 
-        self.assertEqual(imghdr.what(output), 'gif')
+        self.assertEqual(filetype.guess_extension(output), 'gif')
         self.assertIsInstance(return_value, GIFImageFile)
         self.assertEqual(return_value.f, output)
 
@@ -232,7 +232,7 @@ class TestWandOperations(unittest.TestCase):
         return_value = self.image.save_as_webp(output)
         output.seek(0)
 
-        self.assertEqual(imghdr.what(output), 'webp')
+        self.assertEqual(filetype.guess_extension(output), 'webp')
         self.assertIsInstance(return_value, WebPImageFile)
         self.assertEqual(return_value.f, output)
 


### PR DESCRIPTION
Since [imghdr is deprecated](https://peps.python.org/pep-0594/#imghdr) replace it with `filetype` package.
This would allow adding support for more image file types like [heic](https://github.com/wagtail/Willow/issues/90).