### PR TITLE
Block broken 1.1.0 version of filetype library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     ],
     python_requires='>=3.7',
     install_requires=[
-        "filetype>=1.0.10",
+        "filetype>=1.0.10,!=1.1.0",
     ],
     extras_require={"testing": [
         "Pillow>=6.0.0,<10.0.0",


### PR DESCRIPTION
Invoking filetype on file-like objects is broken in 1.1.0: https://github.com/h2non/filetype.py/issues/130 - this causes numerous test failures. The fix is already merged into git, so blocking this one faulty release should be sufficient.