### PR TITLE
Re-add williow.image import in __init__

### DIFF
--- a/willow/__init__.py
+++ b/willow/__init__.py
@@ -1,3 +1,6 @@
+from willow.image import Image  # noqa: F401
+
+
 def setup():
     from xml.etree import ElementTree
 


### PR DESCRIPTION
#116 removed the global image import in the module __init__

Wagtail breaks without it