### PR TITLE
Add optional heif dependency to allow installing via willow[heif]

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,3 +22,19 @@ or Wand.
 
 Note that Pillow doesn't support animated GIFs and Wand isn't as fast.
 Installing both will give best results.
+
+
+HEIC and AVIF support
+^^^^^^^^^^^^^^^^^^^^^
+
+When using Pillow, you need to install ``pillow-heif`` for AVIF and HEIC support:
+
+.. code-block:: shell
+
+    pip install pillow-heif
+    # or
+    pip install Willow[heif]
+
+When using Wand, you will need ImageMagick version 7.0.25 or newer.
+
+Both Pillow and Wand require ``libheif`` to be installed on your system for full HEIC support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+heif = [
+    "pillow-heif>=0.10.0,<1.0.0",
+]
 testing = [
     "Pillow>=9.1.0,<11.0.0",
     "Wand>=0.6,<1.0",
     "mock>=3.0,<4.0",
-    "pillow-heif>=0.7.0,<1.0.0",
+    "pillow-heif>=0.10.0,<1.0.0",
     "black==22.3.0",
     "ruff==0.0.275",
     "coverage[toml]>=7.2.7,<8.0",


### PR DESCRIPTION
and bumps pillow-heif to min 0.10.0 since it brings perf improvements, and 0.9.1 dropped Python 3.7 support