### PR TITLE
Ensure SVG files are given a mime type

### DIFF
--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -92,6 +92,7 @@ class TestDetectImageFormatFromStream(unittest.TestCase):
         image = Image.open(f)
         self.assertIsInstance(image, SvgImageFile)
         self.assertEqual(image.format_name, "svg")
+        self.assertEqual(image.mime_type, "image/svg+xml")
 
     def test_invalid_svg_raises(self):
         f = io.BytesIO(b"<svg><")

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -40,6 +40,15 @@ class TestImageFile(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             broken.mime_type
 
+    def test_implementations_have_required_methods(self):
+        for image_class in ImageFile.__subclasses__():
+            if image_class == BrokenImageFileImplementation:
+                continue
+
+            with self.subTest(image_class):
+                self.assertTrue(hasattr(image_class, "mime_type"))
+                self.assertTrue(hasattr(image_class, "format_name"))
+
 
 class TestDetectImageFormatFromStream(unittest.TestCase):
     """

--- a/willow/image.py
+++ b/willow/image.py
@@ -304,6 +304,7 @@ class WebPImageFile(ImageFile):
 
 class SvgImageFile(ImageFile):
     format_name = "svg"
+    mime_type = "image/svg+xml"
 
     def __init__(self, f, dom=None):
         if dom is None:


### PR DESCRIPTION
`SvgImageFile` currently doesn't conform to the `ImageFile` interface, as it doesn't define `mime_type`.

It might be nice to define `ImageFile` as a proper ABC, but that's a conversation for another day. There are a few stream types too which will need to be considered 