### PR TITLE
Tidy up testing linting deps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4
@@ -29,14 +29,9 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        include:
-          - python: "3.8"
-          - python: "3.9"
-          - python: "3.10"
-          - python: "3.11"
-          - python: "3.12"
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install optimizers
         run: | 
           sudo apt-get install -y jpegoptim pngquant gifsicle optipng libjpeg-progs webp
@@ -66,7 +61,7 @@ jobs:
     needs: test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: ${{env.PYTHON_LATEST}}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,12 @@ default_language_version:
   python: python3
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.1
+    rev: 23.10.1
     hooks:
       - id: black
-        language_version: python3
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.0.291'
+    rev: 'v0.1.2'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,14 @@
 default_language_version:
   python: python3
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
     hooks:
       - id: black
         language_version: python3
-        args: ['--target-version', 'py37']
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.0.275'
+    rev: 'v0.0.291'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ testing = [
 ]
 docs = [
     "Sphinx>=7.0",
-    "sphinx-wagtail-theme==6.0.0",
+    "sphinx-wagtail-theme>=6.1.1,<7.0",
     "sphinxcontrib-spelling>=8.0,<9.0",
     "sphinx_copybutton>=0.5"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,8 @@ heif = [
 
 testing = [
     "willow[pillow,wand,heif]",
-    "black==22.3.0",
-    "ruff==0.0.275",
     "coverage[toml]>=7.2.7,<8.0",
+    "pre-commit>=3.4.0"
 ]
 docs = [
     "Sphinx>=7.0",

--- a/willow/registry.py
+++ b/willow/registry.py
@@ -157,9 +157,7 @@ class WillowRegistry:
 
             if not image_classes:
                 raise UnrecognisedOperationError(
-                    "Could not find image class with the '{}' operation".format(
-                        with_operation
-                    )
+                    f"Could not find image class with the '{with_operation}' operation"
                 )
 
         if available:


### PR DESCRIPTION
Builds on #130 and 
- drops the mock library dependency
- updates the linters
- uses actions/checkout@v4 in CI