### PR TITLE
test_image.py: replace wrong unicdoe character

### DIFF
--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -182,7 +182,7 @@ class TestImageFormats(unittest.TestCase):
         self.assertIsInstance(image, HeicImageFile)
         self.assertEqual(width, 320)
         self.assertEqual(height, 241)
-        self.assertEqual(image.mime_type, "image/heiс")
+        self.assertEqual(image.mime_type, "image/heic")
 
     def test_avif(self):
         with open("tests/images/tree.avif", "rb") as f:
@@ -217,7 +217,7 @@ class TestSaveImage(unittest.TestCase):
             buf.seek(0)
             image = Image.open(buf)
             self.assertIsInstance(image, HeicImageFile)
-            self.assertEqual(image.mime_type, "image/heiс")
+            self.assertEqual(image.mime_type, "image/heic")
 
     def test_save_as_avif(self):
         with open("tests/images/sails.bmp", "rb") as f:

--- a/willow/image.py
+++ b/willow/image.py
@@ -324,7 +324,7 @@ class HeicImageFile(ImageFile):
 
     @property
     def mime_type(self):
-        return "image/heiс"
+        return "image/heic"
 
 
 class AvifImageFile(ImageFile):


### PR DESCRIPTION
The character U+0441 "с" was changed to the ASCII character U+0063 "c".