### PR TITLE
Clean up `auto_orient` logic

### DIFF
--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -4,8 +4,8 @@ import unittest
 from unittest import mock
 
 import filetype
+from PIL import ExifTags, ImageChops
 from PIL import Image as PILImage
-from PIL import ImageChops
 
 from willow.image import (
     AvifImageFile,
@@ -445,6 +445,12 @@ class TestPillowImageOrientation(unittest.TestCase):
         self.assertAlmostEqual(colour[1], 93, delta=25)
         self.assertAlmostEqual(colour[2], 65, delta=25)
 
+    def assert_orientation_metadata_to_be(self, image, expect_orientation):
+        image_exif = image.image.getexif()
+        orientation = image_exif.get(ExifTags.Base.Orientation)
+
+        self.assertEqual(orientation, expect_orientation)
+
     def test_jpeg_with_orientation_1(self):
         with open("tests/images/orientation/landscape_1.jpg", "rb") as f:
             image = PillowImage.open(JPEGImageFile(f))
@@ -453,6 +459,11 @@ class TestPillowImageOrientation(unittest.TestCase):
 
         self.assert_orientation_landscape_image_is_correct(image)
 
+        # This is a special case. The image is already in the correct orientation
+        # so the auto_orient method should not have changed anything.
+        # The default orientation is 1, so we expect that to be the orientation metadata
+        self.assert_orientation_metadata_to_be(image, expect_orientation=1)
+
     def test_jpeg_with_orientation_2(self):
         with open("tests/images/orientation/landscape_2.jpg", "rb") as f:
             image = PillowImage.open(JPEGImageFile(f))
@@ -460,6 +471,7 @@ class TestPillowImageOrientation(unittest.TestCase):
         image = image.auto_orient()
 
         self.assert_orientation_landscape_image_is_correct(image)
+        self.assert_orientation_metadata_to_be(image, None)
 
     def test_jpeg_with_orientation_3(self):
         with open("tests/images/orientation/landscape_3.jpg", "rb") as f:
@@ -468,6 +480,7 @@ class TestPillowImageOrientation(unittest.TestCase):
         image = image.auto_orient()
 
         self.assert_orientation_landscape_image_is_correct(image)
+        self.assert_orientation_metadata_to_be(image, None)
 
     def test_jpeg_with_orientation_4(self):
         with open("tests/images/orientation/landscape_4.jpg", "rb") as f:
@@ -476,6 +489,7 @@ class TestPillowImageOrientation(unittest.TestCase):
         image = image.auto_orient()
 
         self.assert_orientation_landscape_image_is_correct(image)
+        self.assert_orientation_metadata_to_be(image, None)
 
     def test_jpeg_with_orientation_5(self):
         with open("tests/images/orientation/landscape_5.jpg", "rb") as f:
@@ -484,6 +498,7 @@ class TestPillowImageOrientation(unittest.TestCase):
         image = image.auto_orient()
 
         self.assert_orientation_landscape_image_is_correct(image)
+        self.assert_orientation_metadata_to_be(image, None)
 
     def test_jpeg_with_orientation_6(self):
         with open("tests/images/orientation/landscape_6.jpg", "rb") as f:
@@ -492,6 +507,7 @@ class TestPillowImageOrientation(unittest.TestCase):
         image = image.auto_orient()
 
         self.assert_orientation_landscape_image_is_correct(image)
+        self.assert_orientation_metadata_to_be(image, None)
 
     def test_jpeg_with_orientation_7(self):
         with open("tests/images/orientation/landscape_7.jpg", "rb") as f:
@@ -500,6 +516,7 @@ class TestPillowImageOrientation(unittest.TestCase):
         image = image.auto_orient()
 
         self.assert_orientation_landscape_image_is_correct(image)
+        self.assert_orientation_metadata_to_be(image, None)
 
     def test_jpeg_with_orientation_8(self):
         with open("tests/images/orientation/landscape_8.jpg", "rb") as f:
@@ -508,3 +525,4 @@ class TestPillowImageOrientation(unittest.TestCase):
         image = image.auto_orient()
 
         self.assert_orientation_landscape_image_is_correct(image)
+        self.assert_orientation_metadata_to_be(image, None)

--- a/willow/plugins/pillow.py
+++ b/willow/plugins/pillow.py
@@ -29,6 +29,12 @@ def _PIL_Image():
     return PIL.Image
 
 
+def _PIL_ImageOps():
+    import PIL.ImageOps
+
+    return PIL.ImageOps
+
+
 class PillowImage(Image):
     def __init__(self, image):
         self.image = image
@@ -311,40 +317,9 @@ class PillowImage(Image):
     def auto_orient(self):
         # JPEG files can be orientated using an EXIF tag.
         # Make sure this orientation is applied to the data
-        image = self.image
-
-        if hasattr(image, "_getexif"):
-            try:
-                exif = image._getexif()
-            except Exception:  # noqa: BLE001
-                # Blanket cover all the ways _getexif can fail in.
-                exif = None
-            if exif is not None:
-                # 0x0112 = Orientation
-                orientation = exif.get(0x0112, 1)
-
-                if 1 <= orientation <= 8:
-                    Image = _PIL_Image()
-                    ORIENTATION_TO_TRANSPOSE = {
-                        1: (),
-                        2: (Image.Transpose.FLIP_LEFT_RIGHT,),
-                        3: (Image.Transpose.ROTATE_180,),
-                        4: (
-                            Image.Transpose.ROTATE_180,
-                            Image.Transpose.FLIP_LEFT_RIGHT,
-                        ),
-                        5: (
-                            Image.Transpose.ROTATE_270,
-                            Image.Transpose.FLIP_LEFT_RIGHT,
-                        ),
-                        6: (Image.Transpose.ROTATE_270,),
-                        7: (Image.Transpose.ROTATE_90, Image.Transpose.FLIP_LEFT_RIGHT),
-                        8: (Image.Transpose.ROTATE_90,),
-                    }
-
-                    for transpose in ORIENTATION_TO_TRANSPOSE[orientation]:
-                        image = image.transpose(transpose)
-
+        # and the metadata is updated to reflect this.
+        ImageOps = _PIL_ImageOps()
+        image = ImageOps.exif_transpose(self.image)
         return PillowImage(image)
 
     @Image.operation


### PR DESCRIPTION
Move away from bespoke logic and rely on `ImageOps.exif_transpose()`. This method works much better than our own as it also supports reading XMP metadata instead of just EXIF.

In addition, it also removes the orientation metadata from the transposed image.

This method was added in Pillow 6.0.0.
See: https://github.com/python-pillow/Pillow/blob/28c173f8d4767c7f6dd22dc840117fe641f4d3ee/docs/releasenotes/6.0.0.rst#added-imageopsexif_transpose

This fixes #137 in the process by removing stale orientation metadata.