### PR TITLE
Fix incorrect method name for `save_as_heic` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ As neither Pillow nor Wand support detecting faces, Willow would automatically c
 | `save_as_png(file)`                              | ✓      | ✓    |        |
 | `save_as_gif(file)`                              | ✓      | ✓    |        |
 | `save_as_webp(file, quality)`                    | ✓      | ✓    |        |
-| `save_as_heif(file, quality, lossless)`          | ✓⁺     |      |        |
+| `save_as_heic(file, quality, lossless)`          | ✓⁺     |      |        |
 | `save_as_avif(file, quality, lossless)`          | ✓⁺     | ✓⁺   |        |
 | `save_as_ico(file)`                              | ✓      | ✓    |        |
 | `has_alpha()`                                    | ✓      | ✓    | ✓\*    |


### PR DESCRIPTION
The actual method is `save_as_heic`:

https://github.com/wagtail/Willow/blob/84ab87fb9241efb45317d45f7cdf70a0d202c131/willow/plugins/pillow.py#L378-L387

https://willow.wagtail.org/latest/guide/save.html#lossless-avif-heic-and-webp