### PR TITLE
Link directly to the right changelog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ docs = [
 
 [project.urls]
 Source = "https://github.com/wagtail/Willow"
-Changelog = "https://github.com/wagtail/Willow/blob/main/CHANGELOG.txt"
+Changelog = "https://willow.wagtail.org/latest/changelog.html"
 Documentation = "https://willow.wagtail.org/"
 
 


### PR DESCRIPTION
Followed the 'changelog' link on PyPI and ended up at https://github.com/wagtail/Willow/blob/main/CHANGELOG.txt.

Let's make that right.