### PR TITLE
Fix Github Actions for Ubuntu 24.04 base image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,12 @@ jobs:
         python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
-      - name: Install optimizers
+      - name: Install required system packages
         run: |
+          sudo apt-get update -y
+          # For Wand tests
+          sudo apt-get install -y imagemagick
+          # For testing optimizers
           sudo apt-get install -y jpegoptim pngquant gifsicle optipng libjpeg-progs webp
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: ${{ env.PYTHON_LATEST }}
       - uses: pre-commit/action@v3.0.1
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # Testsuite fails on 24.04 due to issues related to ImageMagick
     needs: lint
     strategy:
       matrix:


### PR DESCRIPTION
Github actions has now defaulted to using its Ubuntu 24.04 base image.
Compared to the previous base image, this is missing many pre-installed
binaries. Such as imagemagick.

Comparison:

- Ubuntu 24.04: https://github.com/actions/runner-images/blob/ubuntu24/20241215.1/images/ubuntu/Ubuntu2404-Readme.md
- Ubuntu 22.04: https://github.com/actions/runner-images/blob/ubuntu24/20241215.1/images/ubuntu/Ubuntu2204-Readme.md