### PR TITLE
Pin test workflow on Ubuntu 22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,9 @@ jobs:
           python-version: ${{ env.PYTHON_LATEST }}
       - uses: pre-commit/action@v3.0.1
   test:
-    runs-on: ubuntu-latest
+    # There is an an issue with Wand / ImageMagick using the Ubuntu 24.04 image
+    # See https://github.com/wagtail/Willow/issues/161
+    runs-on: ubuntu-22.04
     needs: lint
     strategy:
       matrix:


### PR DESCRIPTION
Intermediate solution for now to get the testsuite passing again. See discussion on https://github.com/wagtail/Willow/pull/160#discussion_r1923508422