### PR TITLE
Run tests against Python 3.14 prerelease

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - name: Install optimizers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 dynamic = ["version"]  # will read __version__ from willow/__init__.py


### PR DESCRIPTION
We already have the `allow-prerelease` flag set to allow prereleases: https://github.com/wagtail/Willow/blob/d77b646848f405e7c78b704af0b84b434ddaf500/.github/workflows/test.yml#L43-L47