### PR TITLE
Use native Pillow v11.2.0 AVIF format

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ As neither Pillow nor Wand support detecting faces, Willow would automatically c
 | `save_as_gif(file)`                              | ✓      | ✓    |        |
 | `save_as_webp(file, quality)`                    | ✓      | ✓    |        |
 | `save_as_heic(file, quality, lossless)`          | ✓⁺     |      |        |
-| `save_as_avif(file, quality, lossless)`          | ✓⁺     | ✓⁺   |        |
+| `save_as_avif(file, quality, lossless)`          | ✓      | ✓    |        |
 | `save_as_ico(file)`                              | ✓      | ✓    |        |
 | `has_alpha()`                                    | ✓      | ✓    | ✓\*    |
 | `has_animation()`                                | ✓\*    | ✓    | ✓\*    |

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,10 +33,10 @@ Note that Pillow doesn't support animated GIFs and Wand isn't as fast.
 Installing both will give best results.
 
 
-HEIC and AVIF support
-^^^^^^^^^^^^^^^^^^^^^
+HEIC support
+^^^^^^^^^^^^
 
-When using Pillow, you need to install ``pillow-heif`` for AVIF and HEIC support:
+When using Pillow, you need to install ``pillow-heif`` for HEIC support:
 
 .. code-block:: shell
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -337,7 +337,7 @@ Here's a full list of operations provided by Willow out of the box:
     (requires the `pillow-heif <https://pypi.org/project/pillow-heif/>`_ library)
 
     Saves the image to the specified file-like object in AVIF format.
-    When saving with `lossless=True`, the `quality` value is set to `-1` and `chroma` to `444`.
+    When saving with `lossless=True`, no `chroma subsampling <https://en.wikipedia.org/wiki/Chroma_subsampling>` is used (4:4:4 instead of the default 4:2:0).
 
     returns a ``AvifImageFile`` wrapping the file.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-pillow = ["Pillow>=9.1.0,<12.0.0"]
+pillow = ["Pillow>=11.2.0,<12.0.0"]
 wand = ["Wand>=0.6,<1.0"]
 heif = [
     "pillow-heif>=0.10.0,<1.0.0; python_version < '3.12'",

--- a/willow/plugins/pillow.py
+++ b/willow/plugins/pillow.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 
 try:
-    from pillow_heif import AvifImagePlugin, HeifImagePlugin  # noqa: F401
+    from pillow_heif import HeifImagePlugin  # noqa: F401
 except ImportError:
     pass
 
@@ -425,7 +425,12 @@ class PillowImage(Image):
     def save_as_avif(self, f, quality=80, lossless=False, apply_optimizers=True):
         kwargs = {"quality": quality}
         if lossless:
-            kwargs = {"quality": -1, "chroma": 444}
+            kwargs = {
+                # Quality of 100 implies lossless (according to libavif documentation)
+                "quality": 100,
+                # When encoding lossless images, don't use chroma subsampling (4:4:4 retains the most information)
+                "subsampling": "4:4:4",
+            }
 
         image = self.image
         icc_profile = self.get_icc_profile()


### PR DESCRIPTION
Fixes https://github.com/wagtail/Willow/issues/166

Pillow v11.2.0 was released today with AVIF support as a notable new feature. 

Requires raising the minimum version of Pillow. Only the latest Pillow release receives active support so requiring the latest version doesn't seem like a big issue to me. Especially now that AVIF support in pillow-heif is deprecated, as noted in https://github.com/wagtail/Willow/issues/166