### PR TITLE
Fix broken AVIF support when used with Pillow 11.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,9 @@ dependencies = [
 pillow = ["Pillow>=9.1.0,<12.0.0"]
 wand = ["Wand>=0.6,<1.0"]
 heif = [
-    "pillow-heif>=0.10.0,<1.0.0; python_version < '3.12'",
-    "pillow-heif>=0.13.0,<1.0.0; python_version >= '3.12'",
+    # Pinned because pillow-heif 0.23+ has dropped AVIF support but we still rely on it.
+    "pillow-heif>=0.10.0,<0.22.0; python_version < '3.12'",
+    "pillow-heif>=0.13.0,<0.22.0; python_version >= '3.12'",
 ]
 
 testing = [

--- a/runtests.py
+++ b/runtests.py
@@ -6,6 +6,7 @@ import unittest
 from tests.test_image import *  # noqa: F403
 from tests.test_optimizers import *  # noqa: F403
 from tests.test_pillow import *  # noqa: F403
+from tests.test_pillow_avif_plugin import *  # noqa: F403
 from tests.test_registry import *  # noqa: F403
 from tests.test_svg_coordinate_transforms import *  # noqa: F403
 from tests.test_svg_image import *  # noqa: F403

--- a/tests/test_pillow_avif_plugin.py
+++ b/tests/test_pillow_avif_plugin.py
@@ -1,0 +1,29 @@
+import unittest
+
+from pillow_heif import AvifImageFile as PillowHeif_AvifImageFile
+
+from willow.image import Image, PNGImageFile
+from willow.plugins.pillow import PillowImage
+
+no_avif_support = not PillowImage.is_format_supported("AVIF")
+
+
+class TestPillowAVIFPlugin(unittest.TestCase):
+    def setUp(self):
+        # Open an image of a different format first, this ensures that Pillow
+        # registers its own AVIF format support *before* pillow_heif does.
+        # The order of registration carries significance.
+        with open("tests/images/transparent.png", "rb") as f:
+            self.image = PillowImage.open(PNGImageFile(f))
+
+    @unittest.skipIf(no_avif_support, "Pillow does not have AVIF support")
+    def test_avif_plugin_loads_correctly(self):
+        # Opening an AVIF image after opening a different format image
+        # should not cause any issues with AVIF support.
+        with open("tests/images/tree.avif", "rb") as f:
+            image = Image.open(f)
+            pillow = PillowImage.open(image)
+
+            # The image should have been opened using pillow_heif
+            # and not the default AVIF plugin.
+            self.assertIsInstance(pillow.image, PillowHeif_AvifImageFile)

--- a/willow/plugins/pillow.py
+++ b/willow/plugins/pillow.py
@@ -1,7 +1,11 @@
 from io import BytesIO
 
 try:
-    from pillow_heif import AvifImagePlugin, HeifImagePlugin  # noqa: F401
+    # Need to import Pillow's AVIF plugin here to make it register. The next import
+    # will replace the default AVIF plugin with pillow_heif's.
+    # Otherwise the inverse might happen and the wrong AVIF plugin will be used.
+    from PIL import AvifImagePlugin  # noqa: F401
+    from pillow_heif import AvifImagePlugin, HeifImagePlugin  # noqa: F811, F401
 except ImportError:
     pass
 


### PR DESCRIPTION
See @laymonage's comment: https://github.com/python-pillow/Pillow/issues/8886#issuecomment-2813504451
This applies the fix proposed on that discussion by Andrew Murray - thank you

Also pinning pillow_heif for now so our users don't end up pulling in a version of that package that no longer has AVIF support. We should either move to https://github.com/fdintino/pillow-avif-plugin (unsure what the future of that plugin looks like now that AVIF support has technically shipped in Pillow) or wait for Pillow 11.3.0 due for release next quarter which has the potential of shipping full AVIF support

See also #167 for more background