### PR TITLE
Remove sysmon coverage core setting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ env:
   FORCE_COLOR: "1" # Make tools pretty.
   TOX_TESTENV_PASSENV: FORCE_COLOR
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
-  COVERAGE_CORE: sysmon # Only supported on Python 3.12+, ignore on older versions
   PYTHON_LATEST: "3.14"
 
 jobs:


### PR DESCRIPTION
Coverage.py will now error if incompatible settings are used. In our case, the incompatible setting is the `branch` setting.

Coverage on Python 3.14+ should automatically use sysmon.