### PR TITLE
Fix OpenCV 5+ compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           cache: pip
       - name: Install dependencies
         run: |
-          python -Im pip install --upgrade pip opencv-python-headless
+          python -Im pip install --upgrade pip opencv-contrib-python-headless
           python -Im pip install -e .[testing]
       - name: Test
         run: coverage run --parallel-mode -m runtests --opencv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used to easily run the OpenCV tests without having to install OpenCV on the host machine.
-FROM python:3.13-slim-bookworm
+FROM python:3.14-slim-trixie
 RUN apt update && apt install -y imagemagick
-RUN pip install opencv-python-headless
+RUN pip install opencv-contrib-python-headless
 
 WORKDIR /code
 COPY . ./

--- a/willow/plugins/opencv.py
+++ b/willow/plugins/opencv.py
@@ -8,6 +8,15 @@ def _cv2():
         import cv2
     except ImportError:
         from cv import cv2
+
+    try:
+        # Check if cv2.CascadeClassifier is available (it is split into a separate package in OpenCV 5.0+)
+        _ = cv2.CascadeClassifier
+    except AttributeError:
+        raise ImportError(
+            "OpenCV is installed, but cv2.CascadeClassifier is not available. "
+            "You likely need to install opencv-contrib-python instead."
+        )
     return cv2
 
 


### PR DESCRIPTION
### Description

In the recently released OpenCV 5.0, `cv2.CascadeClassifier` has moved to the opencv-contrib package ([relevant migrating to v5.0 section](https://github.com/opencv/opencv/wiki/OpenCV-4-to-5-migration#objdetect-haar-and-hog-moved-to-contrib)). Adjust our dependency installation code accordingly and add a message for end-users that might run into it.


### AI usage

None